### PR TITLE
absoluteFilePath() instead of canonicalFilePath()

### DIFF
--- a/src/settings/contextmenu/servicemenuinstaller/servicemenuinstaller.cpp
+++ b/src/settings/contextmenu/servicemenuinstaller/servicemenuinstaller.cpp
@@ -204,7 +204,7 @@ QString findRecursive(const QString &dir, const QString &basename)
 {
     QDirIterator it(dir, QStringList{basename}, QDir::Files, QDirIterator::Subdirectories);
     while (it.hasNext()) {
-        return QFileInfo(it.next()).canonicalFilePath();
+        return QFileInfo(it.next()).absoluteFilePath();
     }
 
     return QString();


### PR DESCRIPTION
`canonicalFilePath()` "failes" on symbolic links.  If we have `uninstall.sh` existing as a symbolic link to `install.sh`, `canonicalFilePath()` will return a "stripped" version, i.e. it returns `install.sh` instead of `uninstall.sh`. Consequently `install.sh` (*without any arguments given*) will be called and no de-installation will take place, as the `install.sh` script tries to determine it's own name via (e.g.) `${BASH_SOURCE[0]}` and that is just `install.sh`.